### PR TITLE
Change to license package.json to use a SPDX license idenftifier

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "Responsive"
   ],
   "author": "Jitae Kim <originerd@gmail.com> (http://originerd.com)",
-  "license": "THE BEER-WARE LICENSE",
+  "license": "Beerware",
   "bugs": {
     "url": "https://github.com/huiseoul/react-native-fit-image/issues"
   },


### PR DESCRIPTION
Hi @originerd, this PR is based on the [previous issue](https://github.com/huiseoul/react-native-fit-image/issues/66) for the license file

I saw your change on commit 9d7bea7 however I need this to be noted as in the [documentation](https://docs.npmjs.com/files/package.json#license) with an SPDX identifier, [here is a list](https://spdx.org/licenses/) of the supported ids.

Please let me know your thoughts.